### PR TITLE
Add poll dashboard JS.

### DIFF
--- a/priv/assets/js/app/mixins/jobs.coffee
+++ b/priv/assets/js/app/mixins/jobs.coffee
@@ -6,6 +6,15 @@ module.exports =
           callback(resp.data)
         .catch (resp) ->
           console.log resp
+    poll: (params = {}, callback) ->
+      http = @$http
+      setInterval(->
+        http['get'] "/bolt/api/status", params
+          .then (resp) ->
+            callback(resp.data)
+          .catch (resp) ->
+            console.log resp
+      , 3500)
     setWorkers: (queue_name, params = {}, callback)->
       @$http['post'] "/bolt/api/#{queue_name}/workers", params
         .then (resp) ->

--- a/priv/assets/js/app/sandbox.coffee
+++ b/priv/assets/js/app/sandbox.coffee
@@ -4,6 +4,9 @@ module.exports =
     status: null
   ready: ->
     if !@status?
+      @poll({}, (data) =>
+        @status = data
+      )
       @updateStatus()
   methods:
     updateStatus: ->


### PR DESCRIPTION
# Change Summary
* Add behavior to poll the queue status every 3 seconds

# Test Plan
* Pull down this branch
* make sure the new js is built with brunch
* add `Process.sleep 5000` to `Bolt.ExampleWorker.work\1`
* enqueue a bunch `for _ <- 1..100 do Bolt.Queue.enqueue(:bg, %{a: 1, b: 2}) end` 
* visit `/bolt`
* watch the jobs status update every 3.5 seconds




